### PR TITLE
Corrects d_ts type

### DIFF
--- a/main.c
+++ b/main.c
@@ -36,7 +36,7 @@ double ntp_timestamp(AVFormatContext *pFormatCtx, uint32_t *last_rtcp_ts, double
 		*base_time = seconds+useconds;
 	}
 
-	uint32_t d_ts = rtp_demux_context->timestamp-*last_rtcp_ts;
+	int32_t d_ts = rtp_demux_context->timestamp-*last_rtcp_ts;
 	return *base_time+d_ts/90000.0;
 }
 


### PR DESCRIPTION
Sometimes, `last_rtcp_ts` can be greater than` rtp_demux_context-> timestamp` and the unsigned d_ts variable causes the` ntp_timestamp` function to calculate a strange value ... It is better to use int32_t.